### PR TITLE
Content with "@mention" tags when pasted are turning into "@@mentions"

### DIFF
--- a/src/mentions.js
+++ b/src/mentions.js
@@ -21,7 +21,7 @@ export const mentionNodeSpec = {
       class: 'mention',
       'data-mention-type': node.attrs.type,
       'data-mention-id': node.attrs.id,
-      'data-mention-label': node.attrs.label
+      'data-mention-label': node.attrs.label,
     },
     `@${node.attrs.label}`,
   ],

--- a/src/mentions.js
+++ b/src/mentions.js
@@ -21,13 +21,14 @@ export const mentionNodeSpec = {
       class: 'mention',
       'data-mention-type': node.attrs.type,
       'data-mention-id': node.attrs.id,
+      'data-mention-label': node.attrs.label
     },
     `@${node.attrs.label}`,
   ],
 
   parseDOM: [
     {
-      tag: 'span[data-mention-type][data-mention-id]',
+      tag: 'span[data-mention-type][data-mention-id][data-mention-label]',
 
       /**
        * @param {Element} dom
@@ -36,7 +37,7 @@ export const mentionNodeSpec = {
       getAttrs: dom => {
         const type = dom.getAttribute('data-mention-type');
         const id = dom.getAttribute('data-mention-id');
-        const label = dom.innerText;
+        const label = dom.getAttribute('data-mention-label');
 
         return { type, id, label };
       },


### PR DESCRIPTION
Steps to reproduce the bug:

1. Run the example app. 
2. Copy some content along with "@Some User"
3. Paste it into a new paragraph. 
4. Content is pasted as @@Some User 

Fix: 
Instead of preserving label in innerText, preserve it as an attribute. This way we don't have to parse and pop out the first character as a fix.