### PR TITLE
Whitelist the files to be published to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,5 +32,6 @@
     "watch": "rollup -c -w",
     "prepare": "npm run build",
     "test": "jest"
-  }
+  },
+  "files": ["dist"]
 }


### PR DESCRIPTION
Hello, thanks for writing this module! Whilst reviewing it, I noticed that this module uploads a lot more files than necessary to `npm`:

https://unpkg.com/@quartzy/prosemirror-suggestions@0.1.1/

This PR uses the [`files` field in package.json](https://docs.npmjs.com/files/package.json#files) to outline the files that will be published to npm. Note that `files` implicitly includes `package.json`, README, LICENSE, etc; so I believe that just supplying `dist` here is sufficient:

```
$ npm pack

> @quartzy/prosemirror-suggestions@0.1.1 prepare /Users/benjiegillam/Dev/prosemirror-suggestions
> npm run build


> @quartzy/prosemirror-suggestions@0.1.1 build /Users/benjiegillam/Dev/prosemirror-suggestions
> rollup -c


./src/index.js → dist/index.js...
(!) The 'extends' Babel helper is used more than once in your code. It's strongly recommended that you use the "external-helpers" plugin or the "es2015-rollup" preset. See https://github.com/rollup/rollup-plugin-babel#configuring-babel for more information
created dist/index.js in 326ms
npm notice
npm notice 📦  @quartzy/prosemirror-suggestions@0.1.1
npm notice === Tarball Contents ===
npm notice 1.1kB  package.json
npm notice 554B   LICENSE
npm notice 1.8kB  README.md
npm notice 10.5kB dist/index.js
npm notice 14.6kB dist/index.js.map
npm notice === Tarball Details ===
npm notice name:          @quartzy/prosemirror-suggestions
npm notice version:       0.1.1
npm notice filename:      quartzy-prosemirror-suggestions-0.1.1.tgz
npm notice package size:  8.7 kB
npm notice unpacked size: 28.5 kB
npm notice shasum:        51fc11fd5296fb291d8546beb47671c5e2881a8e
npm notice integrity:     sha512-+WDAe8nkvzigC[...]d4dvAsTTy1WUg==
npm notice total files:   5
npm notice
quartzy-prosemirror-suggestions-0.1.1.tgz
```

Here's the new contents of the package:
```
$ tar tf quartzy-prosemirror-suggestions-0.1.1.tgz
package/package.json
package/LICENSE
package/README.md
package/dist/index.js
package/dist/index.js.map
```

Another thing is that your currently published version seems to contain an additional file in `dist` that I assume is from a previous version? You may want to have the `prepare` script delete this dist folder before rebuilding to ensure there's no out of date contents in it.